### PR TITLE
Cleanup and refactoring of expression parsing

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -84,8 +84,8 @@ function parse_function_def(tokens, stack, start, qasm)
     return_type      = QasmExpression(:void) # default
     has_return_type  = next_token_type == arrow_token
     if has_return_type
-        arrow = popfirst!(tokens)
-        next_token_type  = first(tokens)[end]
+        arrow           = popfirst!(tokens)
+        next_token_type = first(tokens)[end]
         if next_token_type == classical_type
             return_type = parse_classical_type(tokens, stack, start, qasm)
         elseif next_token_type == waveform_token
@@ -121,6 +121,7 @@ function parse_classical_type(tokens, stack, start, qasm)
     type_name = popfirst!(tokens)
     type_name[end] == classical_type || throw(QasmParseError("classical variable must have a classical type", stack, start, qasm))
     var_type  = read_raw(type_name, qasm)
+    var_type == "bool"    && return QasmExpression(:classical_type, Bool)
     if var_type == "complex"
         complex_tokens = extract_expression(tokens, lbracket, rbracket, stack, start, qasm)
         eltype = parse_classical_type(complex_tokens, stack, start, qasm)
@@ -142,7 +143,11 @@ function parse_classical_type(tokens, stack, start, qasm)
         return QasmExpression(:classical_type, :stretch)
     else
         !any(triplet->triplet[end] == semicolon, tokens) && push!(tokens, (-1, Int32(-1), semicolon))
-        size = is_sized ? parse_expression(tokens, stack, start, qasm) : QasmExpression(:integer_literal, -1)
+        size = QasmExpression(:integer_literal, -1)
+        if is_sized
+            size_tokens = extract_expression(tokens, lbracket, rbracket, stack, start, qasm)
+            size = parse_expression(push!(size_tokens, (-1, Int32(-1), semicolon)), stack, start, qasm)
+        end
     end
     var_type == "bit"     && return QasmExpression(:classical_type, SizedBitVector(size))
     var_type == "int"     && return QasmExpression(:classical_type, SizedInt(size))
@@ -150,7 +155,6 @@ function parse_classical_type(tokens, stack, start, qasm)
     var_type == "float"   && return QasmExpression(:classical_type, SizedFloat(size))
     var_type == "angle"   && return QasmExpression(:classical_type, SizedAngle(size))
     var_type == "complex" && return QasmExpression(:classical_type, SizedComplex(size))
-    var_type == "bool"    && return QasmExpression(:classical_type, Bool)
     throw(QasmParseError("could not parse classical type", stack, start, qasm))
 end
 
@@ -358,7 +362,8 @@ function expression_start(tokens, stack, start, qasm)
     expr_head   = QasmExpression(:empty)
     if start_token[end] != classical_type && next_token[end] == lbracket
         name      = parse_identifier(start_token, qasm)
-        indices   = parse_expression(tokens, stack, start, qasm)
+        idx_tokens = extract_expression(tokens, lbracket, rbracket, stack, start, qasm)
+        indices   = parse_expression(push!(idx_tokens, (-1, Int32(-1), semicolon)), stack, start, qasm)
         expr_ixs  = length(indices) == 1 ? only(indices) : indices
         expr_head = QasmExpression(:indexed_identifier, name, expr_ixs)
     elseif start_token[end] == identifier || start_token[end] == builtin_gate
@@ -377,9 +382,10 @@ function expression_start(tokens, stack, start, qasm)
         interior_tokens = extract_expression(pushfirst!(tokens, start_token), start_token[end], closing_token(start_token[end]), stack, start, qasm)
         expr_head = parse_list_expression(interior_tokens, stack, start, qasm)
     elseif start_token[end] == classical_type 
-        raw_expr = parse_classical_type(pushfirst!(tokens, start_token), stack, start, qasm)
+        type_tokens = pushfirst!(tokens, start_token)
+        raw_expr = parse_classical_type(type_tokens, stack, start, qasm)
         if !isempty(tokens) && first(tokens)[end] == lparen
-            interior = extract_expression(tokens, lparen, rparen, stack, start, qasm)
+            interior  = extract_expression(tokens, lparen, rparen, stack, start, qasm)
             expr_head = QasmExpression(:cast, raw_expr, parse_expression(interior, stack, start, qasm))
         elseif !isempty(tokens) && first(tokens)[end] == identifier
             expr_head = QasmExpression(:classical_declaration, raw_expr, parse_expression(tokens, stack, start, qasm))
@@ -405,7 +411,8 @@ function expression_start(tokens, stack, start, qasm)
         dim       = replace(replace(raw_dim, " "=>""), "#dim="=>"")
         expr_head = QasmExpression(:n_dims, QasmExpression(:integer_literal, parse(Int, dim)))
     end
-    return expr_head, start_token
+    head(expr_head) == :empty && throw(QasmParseError("unable to parse line with start token $(start_token[end])", stack, start, qasm))
+    return expr_head
 end
 
 function parse_range(expr_head, tokens, stack, start, qasm)
@@ -501,11 +508,9 @@ function parse_function_expr(expr_head, arguments, tokens, stack, start, qasm)
 end
 
 function parse_expression(tokens::Vector{Tuple{Int64, Int32, Token}}, stack, start, qasm)
-    expr_head, start_token = expression_start(tokens, stack, start, qasm)
-    start_token_type       = start_token[end]
-    head(expr_head) == :empty && throw(QasmParseError("unable to parse line with start token $(start_token_type)", stack, start, qasm))
-    next_token             = first(tokens)
-    if next_token[end] ∈ (semicolon, comma) || start_token_type ∈ (lbracket, lbrace)
+    expr_head  = expression_start(tokens, stack, start, qasm)
+    next_token = first(tokens)
+    if next_token[end] ∈ (semicolon, comma)
         expr = expr_head
     elseif next_token[end] == colon
         expr       = parse_range(expr_head, tokens, stack, start, qasm)
@@ -513,18 +518,20 @@ function parse_expression(tokens::Vector{Tuple{Int64, Int32, Token}}, stack, sta
         expr       = parse_classical_assignment(expr_head, tokens, stack, start, qasm)
     elseif next_token[end] == operator
         expr       = parse_binary_op(expr_head, tokens, stack, start, qasm)
-    else # either a gate call or function call
-        arguments  = parse_arguments_list(tokens, stack, start, qasm)
-        next_token = first(tokens)
-        is_gphase::Bool = (head(expr_head) == :identifier && expr_head.args[1]::String == "gphase")::Bool
+    elseif next_token[end] ∈ (lparen, identifier, hw_qubit) # gate call or function call
+        arguments       = parse_arguments_list(tokens, stack, start, qasm)
+        next_token      = first(tokens)
+        is_gphase::Bool = (head(expr_head) == :identifier && name(expr_head)::String == "gphase")::Bool
         # this is a gate call with qubit targets
-        is_gate_call = next_token[end] == identifier || next_token[end] == hw_qubit || is_gphase
+        is_gate_call    = next_token[end] ∈ (identifier, hw_qubit) || is_gphase
         if is_gate_call
             target_expr = QasmExpression(:qubit_targets, parse_list_expression(tokens, stack, start, qasm))
             expr        = QasmExpression(:gate_call, expr_head, arguments, target_expr)
         else # this is a function call
             expr        = parse_function_expr(expr_head, arguments, tokens, stack, start, qasm) 
         end
+    else
+        throw(QasmParseError("unable to parse expression with head $expr_head", stack, start, qasm))
     end
     return expr
 end
@@ -646,7 +653,8 @@ function parse_qasm(clean_tokens::Vector{Tuple{Int64, Int32, Token}}, qasm::Stri
             isnothing(loop_in) && throw(QasmParseError("for loop variable must have in declaration", stack, start, qasm))
             loop_var  = parse_classical_var(splice!(clean_tokens, 1:loop_in-1), stack, start, qasm)
             popfirst!(clean_tokens) # in
-            loop_vals = parse_expression(clean_tokens, stack, start, qasm)
+            val_tokens = extract_expression(clean_tokens, first(clean_tokens)[end], closing_token(first(clean_tokens)[end]), stack, start, qasm)
+            loop_vals = parse_list_expression(push!(val_tokens, (-1, Int32(-1), semicolon)), stack, start, qasm)
             expr      = parse_for_loop(clean_tokens, loop_var[1], loop_var[2], loop_vals, stack, start, qasm)
             push!(stack, expr)
         elseif token == while_block


### PR DESCRIPTION
Move more things into `expression_start` and handle binary ops better, reduce reliance on start token context.